### PR TITLE
fix: reject doctype

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -9,6 +9,7 @@ import { parseMetadata, createIdPMetadataXML, createSPMetadataXML } from './meta
 import { createPostForm } from './post';
 import { sign } from './sign';
 import { decryptXml } from './decrypt';
+import { containsDoctype } from './utils';
 import { parseLogoutResponse, createLogoutRequest, parseLogoutRequest, createLogoutResponse } from './logout';
 import type {
   ParsedLogoutResponse,
@@ -36,6 +37,7 @@ export default {
   decryptXml,
   parseIssuer,
   WrapError,
+  containsDoctype,
   parseLogoutResponse,
   createLogoutRequest,
   parseLogoutRequest,

--- a/lib/logout.ts
+++ b/lib/logout.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import xml2js from 'xml2js';
 import xmlbuilder from 'xmlbuilder';
+import { containsDoctype, doctypeNotAllowedError } from './utils';
 
 type ParsedLogoutResponse = {
   id: string;
@@ -18,6 +19,10 @@ type LogoutRequestParams = {
 
 const parseLogoutResponse = async (rawResponse: string): Promise<ParsedLogoutResponse> => {
   return new Promise((resolve, reject) => {
+    if (containsDoctype(rawResponse)) {
+      reject(doctypeNotAllowedError);
+      return;
+    }
     xml2js.parseString(
       rawResponse,
       { tagNameProcessors: [xml2js.processors.stripPrefix] },
@@ -90,6 +95,10 @@ type LogoutResponseParams = {
 
 const parseLogoutRequest = async (rawRequest: string): Promise<ParsedLogoutRequest> => {
   return new Promise((resolve, reject) => {
+    if (containsDoctype(rawRequest)) {
+      reject(doctypeNotAllowedError);
+      return;
+    }
     xml2js.parseString(
       rawRequest,
       { tagNameProcessors: [xml2js.processors.stripPrefix] },

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,5 +1,6 @@
 import { getAttribute } from './utils';
 import { thumbprint } from './utils';
+import { containsDoctype, doctypeNotAllowedError } from './utils';
 import { stripCertHeaderAndFooter } from './cert';
 
 import crypto from 'crypto';
@@ -13,6 +14,10 @@ const parseMetadata = async (idpMeta: string, validateOpts): Promise<Record<stri
   return new Promise((resolve, reject) => {
     // Some Providers do not escape the & character in the metadata, for now these have been encountered in errorURL
     idpMeta = idpMeta.replace(/errorURL=".*?"/g, '');
+    if (containsDoctype(idpMeta)) {
+      reject(doctypeNotAllowedError);
+      return;
+    }
     xml2js.parseString(
       idpMeta,
       {

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -4,6 +4,7 @@ import { inflateRaw } from 'zlib';
 import xmlbuilder from 'xmlbuilder';
 import { SAMLReq } from './typings';
 import crypto from 'crypto';
+import { containsDoctype, doctypeNotAllowedError } from './utils';
 import { sign } from './sign';
 
 const inflateRawAsync = promisify(inflateRaw);
@@ -74,6 +75,10 @@ const request = ({
 // Parse XML
 const parseXML = (xml: string): Promise<Record<string, any>> => {
   return new Promise((resolve, reject) => {
+    if (containsDoctype(xml)) {
+      reject(doctypeNotAllowedError);
+      return;
+    }
     xml2js.parseString(
       xml,
       {

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -71,6 +71,12 @@ const parseInternal = async (rawAssertion, cb) => {
   }
   // Save the js object derived from xml and check status code
   const assertionObj = await xmlToJs(rawAssertion, cb);
+  // xmlToJs already invoked cb with the parse error; stop so we do not
+  // dereference an undefined object and throw a detached error that would crash
+  // the process. Mirrors validateInternal.
+  if (!assertionObj) {
+    return;
+  }
 
   checkStatusCode(assertionObj, cb);
 

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -7,7 +7,13 @@ import { validateSignature, sanitizeXML } from './validateSignature';
 import { decryptXml } from './decrypt';
 import { select } from 'xpath';
 import saml20 from './saml20';
-import { parseFromString, isMultiRootedXMLError, multiRootedXMLError } from './utils';
+import {
+  parseFromString,
+  isMultiRootedXMLError,
+  multiRootedXMLError,
+  containsDoctype,
+  doctypeNotAllowedError,
+} from './utils';
 import { sign } from './sign';
 
 const nameFormatUri = [
@@ -253,6 +259,9 @@ const validateInternal = async (rawAssertion, options, cb) => {
 const xmlToJs = async (rawAssertion, cb) => {
   try {
     rawAssertion = sanitizeXML(rawAssertion);
+    if (containsDoctype(rawAssertion)) {
+      throw doctypeNotAllowedError;
+    }
     const parser = new xml2js.Parser({
       attrkey: '@',
       charkey: '_',

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -20,10 +20,12 @@ const doctypeNotAllowedError = new Error('doctype not allowed.');
 // so the scan must keep looking for one (e.g. `<!<!--><!DOCTYPE ...>`). To stay
 // linear, once a closing delimiter is absent from the remaining input it is
 // absent for every later position too, so that region type is marked exhausted
-// and no longer rescanned. The trailing `\s` matches the whitespace the XML
-// grammar requires after each keyword (`'<!DOCTYPE' S Name`, etc.).
+// and no longer rescanned. The keyword is matched without requiring trailing
+// whitespace because sax enters its doctype state on the bare keyword (e.g.
+// `<!DOCTYPERoot ...>`), so demanding the XML-grammar whitespace would let such
+// input slip past the guard.
 // See https://github.com/ory/polis/issues/4071.
-const dtdDeclaration = /<!DOCTYPE\s|<!ENTITY\s|<!ELEMENT\s/iy;
+const dtdDeclaration = /<!DOCTYPE|<!ENTITY|<!ELEMENT/iy;
 
 const containsDoctype = (xml: string): boolean => {
   const length = xml.length;
@@ -79,6 +81,14 @@ const countRootNodes = (xmlDoc: Document) => {
 };
 
 const parseFromString = (xmlString: string) => {
+  // Reject a DTD before the parser processes it. Checking only the parsed
+  // `doctype` node (below) lets a malformed DTD make @xmldom/xmldom throw first,
+  // leaking raw parser text (e.g. "doctype not terminated with > at position N")
+  // instead of the fixed error. See https://github.com/ory/polis/issues/4071.
+  if (containsDoctype(xmlString)) {
+    throw doctypeNotAllowedError;
+  }
+
   const errors: string[] = [];
   let multiRootErrFound = false;
   const onError = (level, msg) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -11,21 +11,53 @@ const doctypeNotAllowedError = new Error('doctype not allowed.');
 // XXE-class risk. See https://github.com/ory/polis/issues/4071.
 //
 // Detects a DTD: a `<!DOCTYPE` declaration or an `<!ENTITY`/`<!ELEMENT`
-// declaration, which can only appear inside one. Comments, CDATA sections and
-// processing instructions are removed first so that such text appearing inside
-// them (e.g. in an AttributeValue or a `<?pi ...?>`) is not mistaken for a real
-// declaration. A genuine DTD only appears in the prolog and never inside those
-// regions, so stripping them never hides a real one. The trailing `\s` matches
-// the whitespace the XML grammar requires after each keyword
-// (`'<!DOCTYPE' S Name`, etc.).
-const dtdDeclaration = /<!DOCTYPE\s|<!ENTITY\s|<!ELEMENT\s/i;
+// declaration, which can only appear inside one. A single linear pass skips
+// comments, CDATA sections and processing instructions so that such text
+// appearing inside them (e.g. in an AttributeValue or a `<?pi ...?>`) is not
+// mistaken for a real declaration. Jumping straight to each closing delimiter
+// keeps the scan linear, so adversarial input with many unterminated openers
+// cannot force quadratic rescans. An unterminated region leaves the rest of the
+// document malformed, which the XML parser rejects anyway, so treating it as
+// inert is safe. The trailing `\s` matches the whitespace the XML grammar
+// requires after each keyword (`'<!DOCTYPE' S Name`, etc.).
+// See https://github.com/ory/polis/issues/4071.
+const dtdDeclaration = /<!DOCTYPE\s|<!ENTITY\s|<!ELEMENT\s/iy;
 
 const containsDoctype = (xml: string): boolean => {
-  const withoutInertRegions = xml
-    .replace(/<!--[\s\S]*?-->/g, '')
-    .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '')
-    .replace(/<\?[\s\S]*?\?>/g, '');
-  return dtdDeclaration.test(withoutInertRegions);
+  const length = xml.length;
+  let i = 0;
+  while (i < length) {
+    const lt = xml.indexOf('<', i);
+    if (lt === -1) {
+      return false;
+    }
+    if (xml.startsWith('<!--', lt)) {
+      const end = xml.indexOf('-->', lt + 4);
+      if (end === -1) {
+        return false;
+      }
+      i = end + 3;
+    } else if (xml.startsWith('<![CDATA[', lt)) {
+      const end = xml.indexOf(']]>', lt + 9);
+      if (end === -1) {
+        return false;
+      }
+      i = end + 3;
+    } else if (xml.startsWith('<?', lt)) {
+      const end = xml.indexOf('?>', lt + 2);
+      if (end === -1) {
+        return false;
+      }
+      i = end + 2;
+    } else {
+      dtdDeclaration.lastIndex = lt;
+      if (dtdDeclaration.test(xml)) {
+        return true;
+      }
+      i = lt + 1;
+    }
+  }
+  return false;
 };
 
 const countRootNodes = (xmlDoc: Document) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -12,43 +12,54 @@ const doctypeNotAllowedError = new Error('doctype not allowed.');
 //
 // Detects a DTD: a `<!DOCTYPE` declaration or an `<!ENTITY`/`<!ELEMENT`
 // declaration, which can only appear inside one. A single linear pass skips
-// comments, CDATA sections and processing instructions so that such text
-// appearing inside them (e.g. in an AttributeValue or a `<?pi ...?>`) is not
-// mistaken for a real declaration. Jumping straight to each closing delimiter
-// keeps the scan linear, so adversarial input with many unterminated openers
-// cannot force quadratic rescans. An unterminated region leaves the rest of the
-// document malformed, which the XML parser rejects anyway, so treating it as
-// inert is safe. The trailing `\s` matches the whitespace the XML grammar
-// requires after each keyword (`'<!DOCTYPE' S Name`, etc.).
+// only *terminated* comments, CDATA sections and processing instructions so that
+// such text appearing inside them (e.g. in an AttributeValue or a `<?pi ...?>`)
+// is not mistaken for a real declaration. An unterminated opener is NOT treated
+// as swallowing the rest of the document: a lenient parser (xml2js/sax) can
+// recover from the malformed markup and still process a following declaration,
+// so the scan must keep looking for one (e.g. `<!<!--><!DOCTYPE ...>`). To stay
+// linear, once a closing delimiter is absent from the remaining input it is
+// absent for every later position too, so that region type is marked exhausted
+// and no longer rescanned. The trailing `\s` matches the whitespace the XML
+// grammar requires after each keyword (`'<!DOCTYPE' S Name`, etc.).
 // See https://github.com/ory/polis/issues/4071.
 const dtdDeclaration = /<!DOCTYPE\s|<!ENTITY\s|<!ELEMENT\s/iy;
 
 const containsDoctype = (xml: string): boolean => {
   const length = xml.length;
   let i = 0;
+  let commentCloserExhausted = false;
+  let cdataCloserExhausted = false;
+  let piCloserExhausted = false;
   while (i < length) {
     const lt = xml.indexOf('<', i);
     if (lt === -1) {
       return false;
     }
-    if (xml.startsWith('<!--', lt)) {
+    if (!commentCloserExhausted && xml.startsWith('<!--', lt)) {
       const end = xml.indexOf('-->', lt + 4);
       if (end === -1) {
-        return false;
+        commentCloserExhausted = true;
+        i = lt + 1;
+      } else {
+        i = end + 3;
       }
-      i = end + 3;
-    } else if (xml.startsWith('<![CDATA[', lt)) {
+    } else if (!cdataCloserExhausted && xml.startsWith('<![CDATA[', lt)) {
       const end = xml.indexOf(']]>', lt + 9);
       if (end === -1) {
-        return false;
+        cdataCloserExhausted = true;
+        i = lt + 1;
+      } else {
+        i = end + 3;
       }
-      i = end + 3;
-    } else if (xml.startsWith('<?', lt)) {
+    } else if (!piCloserExhausted && xml.startsWith('<?', lt)) {
       const end = xml.indexOf('?>', lt + 2);
       if (end === -1) {
-        return false;
+        piCloserExhausted = true;
+        i = lt + 1;
+      } else {
+        i = end + 2;
       }
-      i = end + 2;
     } else {
       dtdDeclaration.lastIndex = lt;
       if (dtdDeclaration.test(xml)) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,15 +10,18 @@ const doctypeNotAllowedError = new Error('doctype not allowed.');
 // A DOCTYPE has no legitimate place in SAML XML and accepting one is an
 // XXE-class risk. See https://github.com/ory/polis/issues/4071.
 //
-// Comments and CDATA sections are removed first so that a `<!DOCTYPE` appearing
-// as text inside them (e.g. in an AttributeValue) is not mistaken for a real
-// declaration. A genuine DOCTYPE only appears in the prolog and never inside a
-// comment or CDATA, so stripping those regions never hides a real one.
+// Comments, CDATA sections and processing instructions are removed first so
+// that a `<!DOCTYPE` appearing as text inside them (e.g. in an AttributeValue or
+// a `<?pi ...?>`) is not mistaken for a real declaration. A genuine DOCTYPE only
+// appears in the prolog and never inside those regions, so stripping them never
+// hides a real one. The trailing `\s` matches the whitespace the XML grammar
+// requires after `<!DOCTYPE` (`'<!DOCTYPE' S Name`).
 const containsDoctype = (xml: string): boolean => {
-  const withoutCommentsAndCData = xml
+  const withoutInertRegions = xml
     .replace(/<!--[\s\S]*?-->/g, '')
-    .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '');
-  return /<!DOCTYPE/i.test(withoutCommentsAndCData);
+    .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '')
+    .replace(/<\?[\s\S]*?\?>/g, '');
+  return /<!DOCTYPE\s/i.test(withoutInertRegions);
 };
 
 const countRootNodes = (xmlDoc: Document) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,6 +4,13 @@ import crypto from 'crypto';
 const multiRootedXMLError = new Error('multirooted xml not allowed.');
 const doctypeNotAllowedError = new Error('doctype not allowed.');
 
+// Detects a document type definition (DTD) declaration in a raw XML string.
+// `parseFromString` rejects a DTD via the parsed `doctype` node, but xml2js/sax
+// does not expose one, so its callers screen the raw string with this instead.
+// A DOCTYPE has no legitimate place in SAML XML and accepting one is an
+// XXE-class risk. See https://github.com/ory/polis/issues/4071.
+const containsDoctype = (xml: string): boolean => /<!DOCTYPE/i.test(xml);
+
 const countRootNodes = (xmlDoc: Document) => {
   const rootNodes = Array.from(xmlDoc.childNodes as NodeListOf<Element>).filter(
     (n) => n.tagName != null && n.childNodes != null
@@ -99,4 +106,5 @@ export {
   isMultiRootedXMLError,
   multiRootedXMLError,
   doctypeNotAllowedError,
+  containsDoctype,
 };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -9,7 +9,17 @@ const doctypeNotAllowedError = new Error('doctype not allowed.');
 // does not expose one, so its callers screen the raw string with this instead.
 // A DOCTYPE has no legitimate place in SAML XML and accepting one is an
 // XXE-class risk. See https://github.com/ory/polis/issues/4071.
-const containsDoctype = (xml: string): boolean => /<!DOCTYPE/i.test(xml);
+//
+// Comments and CDATA sections are removed first so that a `<!DOCTYPE` appearing
+// as text inside them (e.g. in an AttributeValue) is not mistaken for a real
+// declaration. A genuine DOCTYPE only appears in the prolog and never inside a
+// comment or CDATA, so stripping those regions never hides a real one.
+const containsDoctype = (xml: string): boolean => {
+  const withoutCommentsAndCData = xml
+    .replace(/<!--[\s\S]*?-->/g, '')
+    .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '');
+  return /<!DOCTYPE/i.test(withoutCommentsAndCData);
+};
 
 const countRootNodes = (xmlDoc: Document) => {
   const rootNodes = Array.from(xmlDoc.childNodes as NodeListOf<Element>).filter(

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,68 +10,25 @@ const doctypeNotAllowedError = new Error('doctype not allowed.');
 // A DOCTYPE has no legitimate place in SAML XML and accepting one is an
 // XXE-class risk. See https://github.com/ory/polis/issues/4071.
 //
-// Detects a DTD: a `<!DOCTYPE` declaration or an `<!ENTITY`/`<!ELEMENT`
-// declaration, which can only appear inside one. A single linear pass skips
-// only *terminated* comments, CDATA sections and processing instructions so that
-// such text appearing inside them (e.g. in an AttributeValue or a `<?pi ...?>`)
-// is not mistaken for a real declaration. An unterminated opener is NOT treated
-// as swallowing the rest of the document: a lenient parser (xml2js/sax) can
-// recover from the malformed markup and still process a following declaration,
-// so the scan must keep looking for one (e.g. `<!<!--><!DOCTYPE ...>`). To stay
-// linear, once a closing delimiter is absent from the remaining input it is
-// absent for every later position too, so that region type is marked exhausted
-// and no longer rescanned. The keyword is matched without requiring trailing
-// whitespace because sax enters its doctype state on the bare keyword (e.g.
-// `<!DOCTYPERoot ...>`), so demanding the XML-grammar whitespace would let such
-// input slip past the guard.
+// A DTD is introduced by `<!DOCTYPE` and may only contain `<!ENTITY`/`<!ELEMENT`
+// declarations, so the presence of any of these keywords means the document
+// carries a DTD. Detection is a single keyword search anywhere in the raw
+// string: it is linear (a fixed alternation with no backtracking) and cannot be
+// evaded. We deliberately do NOT try to ignore the keyword when it appears
+// inside a comment, CDATA section or processing instruction. Doing so requires
+// reproducing the parser's lenient error-recovery tokenizer, and every attempt
+// has been bypassable: a malformed prefix such as `<!<!-->` makes a hand-rolled
+// scanner treat the real `<!DOCTYPE` as comment content (optionally closed by an
+// attacker-supplied trailing `-->`), while sax still processes the DTD. The keyword
+// is matched without requiring trailing whitespace because sax enters its doctype
+// state on the bare keyword (e.g. `<!DOCTYPERoot ...>`). The only cost is
+// rejecting the rare, malformed document that embeds the literal keyword as data;
+// that fails safe, and well-formed XML cannot carry a raw `<` as text (it must be
+// escaped), so a false positive is only possible inside a comment or CDATA.
 // See https://github.com/ory/polis/issues/4071.
-const dtdDeclaration = /<!DOCTYPE|<!ENTITY|<!ELEMENT/iy;
+const dtdDeclaration = /<!DOCTYPE|<!ENTITY|<!ELEMENT/i;
 
-const containsDoctype = (xml: string): boolean => {
-  const length = xml.length;
-  let i = 0;
-  let commentCloserExhausted = false;
-  let cdataCloserExhausted = false;
-  let piCloserExhausted = false;
-  while (i < length) {
-    const lt = xml.indexOf('<', i);
-    if (lt === -1) {
-      return false;
-    }
-    if (!commentCloserExhausted && xml.startsWith('<!--', lt)) {
-      const end = xml.indexOf('-->', lt + 4);
-      if (end === -1) {
-        commentCloserExhausted = true;
-        i = lt + 1;
-      } else {
-        i = end + 3;
-      }
-    } else if (!cdataCloserExhausted && xml.startsWith('<![CDATA[', lt)) {
-      const end = xml.indexOf(']]>', lt + 9);
-      if (end === -1) {
-        cdataCloserExhausted = true;
-        i = lt + 1;
-      } else {
-        i = end + 3;
-      }
-    } else if (!piCloserExhausted && xml.startsWith('<?', lt)) {
-      const end = xml.indexOf('?>', lt + 2);
-      if (end === -1) {
-        piCloserExhausted = true;
-        i = lt + 1;
-      } else {
-        i = end + 2;
-      }
-    } else {
-      dtdDeclaration.lastIndex = lt;
-      if (dtdDeclaration.test(xml)) {
-        return true;
-      }
-      i = lt + 1;
-    }
-  }
-  return false;
-};
+const containsDoctype = (xml: string): boolean => dtdDeclaration.test(xml);
 
 const countRootNodes = (xmlDoc: Document) => {
   const rootNodes = Array.from(xmlDoc.childNodes as NodeListOf<Element>).filter(

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,18 +10,22 @@ const doctypeNotAllowedError = new Error('doctype not allowed.');
 // A DOCTYPE has no legitimate place in SAML XML and accepting one is an
 // XXE-class risk. See https://github.com/ory/polis/issues/4071.
 //
-// Comments, CDATA sections and processing instructions are removed first so
-// that a `<!DOCTYPE` appearing as text inside them (e.g. in an AttributeValue or
-// a `<?pi ...?>`) is not mistaken for a real declaration. A genuine DOCTYPE only
-// appears in the prolog and never inside those regions, so stripping them never
-// hides a real one. The trailing `\s` matches the whitespace the XML grammar
-// requires after `<!DOCTYPE` (`'<!DOCTYPE' S Name`).
+// Detects a DTD: a `<!DOCTYPE` declaration or an `<!ENTITY`/`<!ELEMENT`
+// declaration, which can only appear inside one. Comments, CDATA sections and
+// processing instructions are removed first so that such text appearing inside
+// them (e.g. in an AttributeValue or a `<?pi ...?>`) is not mistaken for a real
+// declaration. A genuine DTD only appears in the prolog and never inside those
+// regions, so stripping them never hides a real one. The trailing `\s` matches
+// the whitespace the XML grammar requires after each keyword
+// (`'<!DOCTYPE' S Name`, etc.).
+const dtdDeclaration = /<!DOCTYPE\s|<!ENTITY\s|<!ELEMENT\s/i;
+
 const containsDoctype = (xml: string): boolean => {
   const withoutInertRegions = xml
     .replace(/<!--[\s\S]*?-->/g, '')
     .replace(/<!\[CDATA\[[\s\S]*?\]\]>/g, '')
     .replace(/<\?[\s\S]*?\?>/g, '');
-  return /<!DOCTYPE\s/i.test(withoutInertRegions);
+  return dtdDeclaration.test(withoutInertRegions);
 };
 
 const countRootNodes = (xmlDoc: Document) => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,6 +2,7 @@ import { DOMParser, MIME_TYPE } from '@xmldom/xmldom';
 import crypto from 'crypto';
 
 const multiRootedXMLError = new Error('multirooted xml not allowed.');
+const doctypeNotAllowedError = new Error('doctype not allowed.');
 
 const countRootNodes = (xmlDoc: Document) => {
   const rootNodes = Array.from(xmlDoc.childNodes as NodeListOf<Element>).filter(
@@ -27,6 +28,16 @@ const parseFromString = (xmlString: string) => {
   };
   try {
     const xml = new DOMParser({ onError }).parseFromString(xmlString, MIME_TYPE.XML_APPLICATION);
+
+    // SAML XML never legitimately declares a document type definition (DTD).
+    // Accepting one exposes the parser to XXE-class attacks: a DTD can declare
+    // entities and its handling makes parser behaviour observable as an oracle.
+    // Reject any document that declares a DOCTYPE. See
+    // https://github.com/ory/polis/issues/4071.
+    if (xml.doctype) {
+      throw doctypeNotAllowedError;
+    }
+
     if (multiRootErrFound) {
       throw multiRootedXMLError;
     } else if (errors.length > 0) {
@@ -81,4 +92,11 @@ const isMultiRootedXMLError = (err: any) => {
   return false;
 };
 
-export { parseFromString, thumbprint, getAttribute, isMultiRootedXMLError, multiRootedXMLError };
+export {
+  parseFromString,
+  thumbprint,
+  getAttribute,
+  isMultiRootedXMLError,
+  multiRootedXMLError,
+  doctypeNotAllowedError,
+};

--- a/test/lib/index.spec.ts
+++ b/test/lib/index.spec.ts
@@ -1,0 +1,16 @@
+import assert from 'assert';
+import { default as saml } from '../../lib/index';
+
+// Locks the public API surface consumers rely on. containsDoctype is exported so
+// callers (e.g. Ory Polis) can reject a DTD before their own XML parsing instead
+// of duplicating the check. See https://github.com/ory/polis/issues/4071.
+describe('index.ts', function () {
+  it('should expose containsDoctype on the default export', function () {
+    assert.strictEqual(typeof saml.containsDoctype, 'function');
+  });
+
+  it('containsDoctype should detect a real DOCTYPE and ignore inert regions', function () {
+    assert.strictEqual(saml.containsDoctype('<!DOCTYPE r><r/>'), true);
+    assert.strictEqual(saml.containsDoctype('<root><![CDATA[<!DOCTYPE x>]]></root>'), false);
+  });
+});

--- a/test/lib/index.spec.ts
+++ b/test/lib/index.spec.ts
@@ -9,8 +9,8 @@ describe('index.ts', function () {
     assert.strictEqual(typeof saml.containsDoctype, 'function');
   });
 
-  it('containsDoctype should detect a real DOCTYPE and ignore inert regions', function () {
+  it('containsDoctype should detect a DTD and be false for clean XML', function () {
     assert.strictEqual(saml.containsDoctype('<!DOCTYPE r><r/>'), true);
-    assert.strictEqual(saml.containsDoctype('<root><![CDATA[<!DOCTYPE x>]]></root>'), false);
+    assert.strictEqual(saml.containsDoctype('<?xml version="1.0"?><root><a>hi</a></root>'), false);
   });
 });

--- a/test/lib/logout.spec.ts
+++ b/test/lib/logout.spec.ts
@@ -6,6 +6,7 @@ import {
   parseLogoutRequest,
   createLogoutResponse,
 } from '../../lib/logout';
+import { doctypeNotAllowedError } from '../../lib/utils';
 
 const response = fs.readFileSync('./test/assets/logout-response.xml').toString();
 const responseFailed = fs.readFileSync('./test/assets/logout-response-failed.xml').toString();
@@ -16,6 +17,21 @@ const requestWithIdToken = fs.readFileSync('./test/assets/logout-request-with-id
 const requestInvalid = 'invalid_data';
 
 describe('logout.ts', function () {
+  // See https://github.com/ory/polis/issues/4071.
+  it('should reject a logout response that declares a DTD', async function () {
+    const dtd =
+      '<?xml version="1.0"?><!DOCTYPE LogoutResponse [ <!ENTITY x SYSTEM "file:///etc/passwd"> ]>' +
+      '<LogoutResponse>&x;</LogoutResponse>';
+    await assert.rejects(parseLogoutResponse(dtd), doctypeNotAllowedError);
+  });
+
+  it('should reject a logout request that declares a DTD', async function () {
+    const dtd =
+      '<?xml version="1.0"?><!DOCTYPE LogoutRequest [ <!ENTITY x SYSTEM "file:///etc/passwd"> ]>' +
+      '<LogoutRequest>&x;</LogoutRequest>';
+    await assert.rejects(parseLogoutRequest(dtd), doctypeNotAllowedError);
+  });
+
   it('response ok', async function () {
     const res = await parseLogoutResponse(response);
     assert.strictEqual(res.id, '_716cfa40a953610d9d68');

--- a/test/lib/logout.spec.ts
+++ b/test/lib/logout.spec.ts
@@ -32,6 +32,13 @@ describe('logout.ts', function () {
     await assert.rejects(parseLogoutRequest(dtd), doctypeNotAllowedError);
   });
 
+  it('should reject a whitespace-free DOCTYPE in a logout message', async function () {
+    await assert.rejects(
+      parseLogoutResponse('<!DOCTYPELogoutResponse SYSTEM "file:///x"><LogoutResponse/>'),
+      doctypeNotAllowedError
+    );
+  });
+
   it('response ok', async function () {
     const res = await parseLogoutResponse(response);
     assert.strictEqual(res.id, '_716cfa40a953610d9d68');

--- a/test/lib/metadata.spec.ts
+++ b/test/lib/metadata.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { parseMetadata, createIdPMetadataXML, createSPMetadataXML } from '../../lib/metadata';
+import { doctypeNotAllowedError } from '../../lib/utils';
 import fs from 'fs';
 
 const samlMetadata = fs.readFileSync('./test/assets/mock-saml-metadata.xml').toString();
@@ -12,6 +13,15 @@ const samlMetadata6 = fs.readFileSync('./test/assets/mock-saml-metadata6.xml').t
 const samlMetadata7 = fs.readFileSync('./test/assets/mock-saml-metadata7.xml').toString();
 
 describe('metadata.ts', function () {
+  // See https://github.com/ory/polis/issues/4071.
+  it('should reject metadata that declares a DTD', async function () {
+    const dtdMetadata =
+      '<?xml version="1.0"?>\n' +
+      '<!DOCTYPE EntityDescriptor [ <!ENTITY x SYSTEM "file:///etc/passwd"> ]>\n' +
+      '<EntityDescriptor entityID="https://saml.example.com/entityid"/>';
+    await assert.rejects(parseMetadata(dtdMetadata, {}), doctypeNotAllowedError);
+  });
+
   it('saml MetaData ok without BEGIN & END notations', async function () {
     const value = await parseMetadata(samlMetadata, {});
     assert.strictEqual(value.entityID, 'https://saml.example.com/entityid');

--- a/test/lib/metadata.spec.ts
+++ b/test/lib/metadata.spec.ts
@@ -22,6 +22,13 @@ describe('metadata.ts', function () {
     await assert.rejects(parseMetadata(dtdMetadata, {}), doctypeNotAllowedError);
   });
 
+  it('should reject metadata with a whitespace-free DOCTYPE', async function () {
+    await assert.rejects(
+      parseMetadata('<!DOCTYPEEntityDescriptor SYSTEM "file:///x"><EntityDescriptor/>', {}),
+      doctypeNotAllowedError
+    );
+  });
+
   it('saml MetaData ok without BEGIN & END notations', async function () {
     const value = await parseMetadata(samlMetadata, {});
     assert.strictEqual(value.entityID, 'https://saml.example.com/entityid');

--- a/test/lib/request.spec.ts
+++ b/test/lib/request.spec.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import fs from 'fs';
 import { decodeBase64, parseSAMLRequest, request } from '../../lib/request';
+import { doctypeNotAllowedError } from '../../lib/utils';
 
 const request1 = fs.readFileSync('./test/assets/request1.xml').toString();
 const request2 = fs.readFileSync('./test/assets/request2.xml').toString();
@@ -17,6 +18,14 @@ const publicKey =
   '-----BEGIN CERTIFICATE-----\nMIIC6jCCAdKgAwIBAgIBATANBgkqhkiG9w0BAQsFADAZMRcwFQYDVQQDEw5Cb3h5SFEgSmFja3NvbjAcFw0yMjA0MDcxOTEyMTBaFwsxMjMxMTgzMDAwWjAZMRcwFQYDVQQDEw5Cb3h5SFEgSmFja3NvbjCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL45bTZRh2sDxoeWBxWYZPnnUW3dnze5E0Iw0ccobNU4BGGbTFjhGEvJr+j6wzPoj6vC+GTTRk2/2pAdepeI/S06fyB2O0v0jDY4fsml7pVG+GZar/S2zRisMvfdWOOgrAmBuUWBXSzRchvnypBrYt6J/Yq5wUe1GQQxZoBoHOtQLs+k1WhXvnMHMuRDQfsRGbeFqhsTyF0VRH6kj42fpaIVu2up521Xi+iyl3ebcvCYshgI92gw2X3+jnvzCMbTeosc7H17C9HYZlr3VPvPq2HRhvariDegZa07j4+I6JNXM21wjK6ca9uQJIUTm5NaiFyWRkU26kd4H0PAse+vDK0CAwEAAaM/MD0wDAYDVR0TAQH/BAIwADAOBgNVHQ8BAf8EBAMCB4AwHQYDVR0OBBYEFI0tLXGuzcZi2eXNI3epHYJwreXQMA0GCSqGSIb3DQEBCwUAA4IBAQAEre2GfP/haRoQo0JYFKqXNsogR1++kFIebn9FTnb64+bDd5DRhV2pOAtAFIWUbm5+YeQIkBbAQmfPFX5OG6WgBSqgJCMpU7ekVwU/tExhxXFaTCRL39pMwLnsJ9R6NIy/WUKrTDW9VtyINE5OIL7lDZbejKbidIuOtdyJtlJrLtnVuhiLmNaZJo+kDKvHYKVmwdEXRMQ5OyR0f53MV4Kq/28dSeUQPe+qKovrcVk3F0J8h+aj/+1bU6VsBfrNSRq1dO/jQM6oIOUI68q3GNBeOCEcDGXpytX5C0HxVmNTz5/ybqB14hEhp343GIZ0/gbdAGmt90uJHoS9Xp4dI77j\n-----END CERTIFICATE-----';
 
 describe('request.ts', function () {
+  // See https://github.com/ory/polis/issues/4071.
+  it('parseSAMLRequest rejects a request that declares a DTD', async function () {
+    const dtd =
+      '<?xml version="1.0"?><!DOCTYPE AuthnRequest [ <!ENTITY x SYSTEM "file:///etc/passwd"> ]>' +
+      '<AuthnRequest>&x;</AuthnRequest>';
+    await assert.rejects(parseSAMLRequest(dtd, false), doctypeNotAllowedError);
+  });
+
   it('request ok', function () {
     assert(
       request({

--- a/test/lib/request.spec.ts
+++ b/test/lib/request.spec.ts
@@ -26,6 +26,13 @@ describe('request.ts', function () {
     await assert.rejects(parseSAMLRequest(dtd, false), doctypeNotAllowedError);
   });
 
+  it('parseSAMLRequest rejects a whitespace-free DOCTYPE', async function () {
+    await assert.rejects(
+      parseSAMLRequest('<!DOCTYPEAuthnRequest SYSTEM "file:///x"><AuthnRequest/>', false),
+      doctypeNotAllowedError
+    );
+  });
+
   it('request ok', function () {
     assert(
       request({

--- a/test/lib/response.spec.ts
+++ b/test/lib/response.spec.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import { parse, parseIssuer, validate, createSAMLResponse } from '../../lib/response';
+import { doctypeNotAllowedError } from '../../lib/utils';
 import fs from 'fs';
 
 const rawResponse = fs.readFileSync('./test/assets/saml20.validResponseSignedMessage.xml').toString();
@@ -54,6 +55,19 @@ describe('response.ts', function () {
       const result = (error as Error).message;
       assert.strictEqual(result, 'An error occurred trying to parse XML assertion.');
     }
+  });
+
+  // xml2js runs on the assertion after xmldom, so it needs its own DTD guard.
+  // See https://github.com/ory/polis/issues/4071.
+  it('RAW response with a DTD is rejected before xml2js', async function () {
+    const dtdResponse =
+      '<?xml version="1.0"?>\n' +
+      '<!DOCTYPE foo [ <!ENTITY x SYSTEM "file:///etc/passwd"> ]>\n' +
+      '<samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol">&x;</samlp:Response>';
+    await assert.rejects(parse(dtdResponse), (err: Error & { inner?: unknown }) => {
+      assert.strictEqual(err.inner, doctypeNotAllowedError);
+      return true;
+    });
   });
 
   it('Should not parse saml 2.0 token which has no assertion', async function () {

--- a/test/lib/response.spec.ts
+++ b/test/lib/response.spec.ts
@@ -70,6 +70,25 @@ describe('response.ts', function () {
     });
   });
 
+  // Rejecting the DTD must not leave a detached async continuation that
+  // dereferences undefined and crashes the process. See ory/polis#4071.
+  it('should not emit an unhandled rejection when parse() rejects a DTD', async function () {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      await assert.rejects(
+        parse('<!DOCTYPE foo [ <!ENTITY x SYSTEM "file:///etc/passwd"> ]><root>ok</root>')
+      );
+      // Let any detached continuation settle before asserting.
+      await new Promise((resolve) => setImmediate(resolve));
+      await new Promise((resolve) => setImmediate(resolve));
+      assert.deepStrictEqual(unhandled, [], 'no detached unhandled rejection');
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled);
+    }
+  });
+
   it('Should not parse saml 2.0 token which has no assertion', async function () {
     try {
       await parse(errorResponse);

--- a/test/lib/utils.spec.ts
+++ b/test/lib/utils.spec.ts
@@ -1,5 +1,11 @@
 import assert from 'assert';
-import { parseFromString, thumbprint, getAttribute, isMultiRootedXMLError } from '../../lib/utils';
+import {
+  parseFromString,
+  thumbprint,
+  getAttribute,
+  isMultiRootedXMLError,
+  doctypeNotAllowedError,
+} from '../../lib/utils';
 
 describe('utils.ts', function () {
   describe('parseFromString', function () {
@@ -21,6 +27,27 @@ describe('utils.ts', function () {
 
     it('should throw error for empty XML', function () {
       assert.throws(() => parseFromString(''), /missing root element/);
+    });
+
+    // A DTD has no legitimate place in SAML XML and enables XXE-class attacks.
+    // See https://github.com/ory/polis/issues/4071.
+    it('should reject XML that declares a DOCTYPE', function () {
+      const xml = '<?xml version="1.0"?>\n<!DOCTYPE foo>\n<root>test</root>';
+      assert.throws(() => parseFromString(xml), doctypeNotAllowedError);
+    });
+
+    it('should reject a DOCTYPE with an internal entity subset (XXE payload)', function () {
+      const xml =
+        '<?xml version="1.0"?>\n' +
+        '<!DOCTYPE foo [ <!ENTITY x SYSTEM "file:///etc/passwd"> ]>\n' +
+        '<root>&x;</root>';
+      assert.throws(() => parseFromString(xml), doctypeNotAllowedError);
+    });
+
+    it('should accept valid XML that does not declare a DOCTYPE', function () {
+      const doc = parseFromString('<?xml version="1.0"?><root><a>hi</a></root>');
+      assert(doc);
+      assert.strictEqual(doc.documentElement?.nodeName, 'root');
     });
   });
 

--- a/test/lib/utils.spec.ts
+++ b/test/lib/utils.spec.ts
@@ -66,6 +66,14 @@ describe('utils.ts', function () {
       );
     });
 
+    it('should detect a standalone ENTITY declaration', function () {
+      assert.strictEqual(containsDoctype('<!ENTITY x SYSTEM "file:///etc/passwd">'), true);
+    });
+
+    it('should detect an ELEMENT declaration', function () {
+      assert.strictEqual(containsDoctype('<!ELEMENT r (#PCDATA)>'), true);
+    });
+
     it('should be case-insensitive', function () {
       assert.strictEqual(containsDoctype('<!doctype html>'), true);
     });

--- a/test/lib/utils.spec.ts
+++ b/test/lib/utils.spec.ts
@@ -105,21 +105,35 @@ describe('utils.ts', function () {
       assert.strictEqual(containsDoctype('<?xml version="1.0"?><!DOCTYPE r><r/>'), true);
     });
 
-    it('should treat an unterminated comment as inert', function () {
-      assert.strictEqual(containsDoctype('<root><!-- <!DOCTYPE x> unterminated'), false);
+    // An unterminated opener must NOT hide a following declaration: lenient
+    // parsers recover from the malformed markup and still process the DTD.
+    it('should detect a DOCTYPE after an unterminated comment', function () {
+      assert.strictEqual(containsDoctype('<root><!-- unterminated <!DOCTYPE x>'), true);
     });
 
-    it('should treat an unterminated CDATA section as inert', function () {
-      assert.strictEqual(containsDoctype('<root><![CDATA[ <!DOCTYPE x> unterminated'), false);
+    it('should detect a DOCTYPE after an unterminated CDATA section', function () {
+      assert.strictEqual(containsDoctype('<root><![CDATA[ unterminated <!DOCTYPE x>'), true);
     });
 
-    it('should treat an unterminated processing instruction as inert', function () {
-      assert.strictEqual(containsDoctype('<?pi <!DOCTYPE x> unterminated'), false);
+    it('should detect a DOCTYPE after an unterminated processing instruction', function () {
+      assert.strictEqual(containsDoctype('<?pi unterminated <!DOCTYPE x>'), true);
+    });
+
+    // Maintainer-reported bypass: a bogus `<!<!-->` prefix must not mask the DTD.
+    it('should detect a DOCTYPE hidden behind a bogus comment prefix', function () {
+      assert.strictEqual(
+        containsDoctype('<!<!--><!DOCTYPE evil [ <!ENTITY x SYSTEM "file:///etc/passwd"> ]><root>ok</root>'),
+        true
+      );
+    });
+
+    it('should return false for an unterminated comment with no declaration', function () {
+      assert.strictEqual(containsDoctype('<root><!-- just an unterminated comment'), false);
     });
 
     it('should scan large adversarial input without quadratic blow-up', function () {
-      // Many unterminated comment openers would force lazy regexes to rescan.
-      // The linear scanner returns at the first unterminated region.
+      // Many unterminated comment openers must not force per-opener rescans; the
+      // exhausted-closer flag keeps the pass linear.
       const hostile = '<!--'.repeat(200000);
       const start = Date.now();
       assert.strictEqual(containsDoctype(hostile), false);

--- a/test/lib/utils.spec.ts
+++ b/test/lib/utils.spec.ts
@@ -5,6 +5,7 @@ import {
   getAttribute,
   isMultiRootedXMLError,
   doctypeNotAllowedError,
+  containsDoctype,
 } from '../../lib/utils';
 
 describe('utils.ts', function () {
@@ -48,6 +49,29 @@ describe('utils.ts', function () {
       const doc = parseFromString('<?xml version="1.0"?><root><a>hi</a></root>');
       assert(doc);
       assert.strictEqual(doc.documentElement?.nodeName, 'root');
+    });
+  });
+
+  // xml2js/sax does not expose a parsed doctype node, so its callers screen the
+  // raw string with containsDoctype. See https://github.com/ory/polis/issues/4071.
+  describe('containsDoctype', function () {
+    it('should detect a DOCTYPE declaration', function () {
+      assert.strictEqual(containsDoctype('<?xml version="1.0"?><!DOCTYPE r><r/>'), true);
+    });
+
+    it('should detect a DOCTYPE with an internal subset', function () {
+      assert.strictEqual(
+        containsDoctype('<!DOCTYPE r [ <!ENTITY x SYSTEM "file:///etc/passwd"> ]><r>&x;</r>'),
+        true
+      );
+    });
+
+    it('should be case-insensitive', function () {
+      assert.strictEqual(containsDoctype('<!doctype html>'), true);
+    });
+
+    it('should return false for XML without a DOCTYPE', function () {
+      assert.strictEqual(containsDoctype('<?xml version="1.0"?><root><a>hi</a></root>'), false);
     });
   });
 

--- a/test/lib/utils.spec.ts
+++ b/test/lib/utils.spec.ts
@@ -104,6 +104,27 @@ describe('utils.ts', function () {
     it('should still detect a real DOCTYPE that follows the XML declaration', function () {
       assert.strictEqual(containsDoctype('<?xml version="1.0"?><!DOCTYPE r><r/>'), true);
     });
+
+    it('should treat an unterminated comment as inert', function () {
+      assert.strictEqual(containsDoctype('<root><!-- <!DOCTYPE x> unterminated'), false);
+    });
+
+    it('should treat an unterminated CDATA section as inert', function () {
+      assert.strictEqual(containsDoctype('<root><![CDATA[ <!DOCTYPE x> unterminated'), false);
+    });
+
+    it('should treat an unterminated processing instruction as inert', function () {
+      assert.strictEqual(containsDoctype('<?pi <!DOCTYPE x> unterminated'), false);
+    });
+
+    it('should scan large adversarial input without quadratic blow-up', function () {
+      // Many unterminated comment openers would force lazy regexes to rescan.
+      // The linear scanner returns at the first unterminated region.
+      const hostile = '<!--'.repeat(200000);
+      const start = Date.now();
+      assert.strictEqual(containsDoctype(hostile), false);
+      assert.ok(Date.now() - start < 1000, 'completed well under a second');
+    });
   });
 
   describe('thumbprint', function () {

--- a/test/lib/utils.spec.ts
+++ b/test/lib/utils.spec.ts
@@ -88,6 +88,14 @@ describe('utils.ts', function () {
     it('should still detect a real DOCTYPE that follows a comment', function () {
       assert.strictEqual(containsDoctype('<!-- a comment --><!DOCTYPE r><r/>'), true);
     });
+
+    it('should ignore <!DOCTYPE inside a processing instruction', function () {
+      assert.strictEqual(containsDoctype('<?pi <!DOCTYPE foo?><root/>'), false);
+    });
+
+    it('should still detect a real DOCTYPE that follows the XML declaration', function () {
+      assert.strictEqual(containsDoctype('<?xml version="1.0"?><!DOCTYPE r><r/>'), true);
+    });
   });
 
   describe('thumbprint', function () {

--- a/test/lib/utils.spec.ts
+++ b/test/lib/utils.spec.ts
@@ -102,48 +102,35 @@ describe('utils.ts', function () {
       assert.strictEqual(containsDoctype('<!doctype html>'), true);
     });
 
-    it('should return false for XML without a DOCTYPE', function () {
+    it('should return false for XML that contains no DTD keyword', function () {
       assert.strictEqual(containsDoctype('<?xml version="1.0"?><root><a>hi</a></root>'), false);
+      assert.strictEqual(containsDoctype('<root><!-- just an ordinary comment --><a>hi</a></root>'), false);
     });
 
-    it('should ignore <!DOCTYPE inside a comment', function () {
-      assert.strictEqual(containsDoctype('<root><!-- <!DOCTYPE example> --><a>hi</a></root>'), false);
-    });
-
-    it('should ignore <!DOCTYPE inside a CDATA section', function () {
-      assert.strictEqual(
-        containsDoctype('<root><AttributeValue><![CDATA[<!DOCTYPE example>]]></AttributeValue></root>'),
-        false
-      );
-    });
-
-    it('should still detect a real DOCTYPE that follows a comment', function () {
+    it('should detect a real DOCTYPE that follows a comment', function () {
       assert.strictEqual(containsDoctype('<!-- a comment --><!DOCTYPE r><r/>'), true);
     });
 
-    it('should ignore <!DOCTYPE inside a processing instruction', function () {
-      assert.strictEqual(containsDoctype('<?pi <!DOCTYPE foo?><root/>'), false);
-    });
-
-    it('should still detect a real DOCTYPE that follows the XML declaration', function () {
+    it('should detect a real DOCTYPE that follows the XML declaration', function () {
       assert.strictEqual(containsDoctype('<?xml version="1.0"?><!DOCTYPE r><r/>'), true);
     });
 
-    // An unterminated opener must NOT hide a following declaration: lenient
-    // parsers recover from the malformed markup and still process the DTD.
-    it('should detect a DOCTYPE after an unterminated comment', function () {
-      assert.strictEqual(containsDoctype('<root><!-- unterminated <!DOCTYPE x>'), true);
+    // The keyword is matched anywhere: attempting to ignore it inside comments,
+    // CDATA or PIs is bypassable, so detection is deliberately conservative and
+    // fails safe. See https://github.com/ory/polis/issues/4071.
+    it('should reject a DTD keyword even inside a comment (fail-safe)', function () {
+      assert.strictEqual(containsDoctype('<root><!-- <!DOCTYPE example> --><a>hi</a></root>'), true);
     });
 
-    it('should detect a DOCTYPE after an unterminated CDATA section', function () {
-      assert.strictEqual(containsDoctype('<root><![CDATA[ unterminated <!DOCTYPE x>'), true);
+    it('should reject a DTD keyword even inside a CDATA section (fail-safe)', function () {
+      assert.strictEqual(
+        containsDoctype('<root><AttributeValue><![CDATA[<!DOCTYPE example>]]></AttributeValue></root>'),
+        true
+      );
     });
 
-    it('should detect a DOCTYPE after an unterminated processing instruction', function () {
-      assert.strictEqual(containsDoctype('<?pi unterminated <!DOCTYPE x>'), true);
-    });
-
-    // Maintainer-reported bypass: a bogus `<!<!-->` prefix must not mask the DTD.
+    // Maintainer-reported bypasses: a bogus `<!<!-->` prefix must not mask the
+    // DTD, including when the attacker appends a trailing `-->`.
     it('should detect a DOCTYPE hidden behind a bogus comment prefix', function () {
       assert.strictEqual(
         containsDoctype('<!<!--><!DOCTYPE evil [ <!ENTITY x SYSTEM "file:///etc/passwd"> ]><root>ok</root>'),
@@ -151,13 +138,18 @@ describe('utils.ts', function () {
       );
     });
 
-    it('should return false for an unterminated comment with no declaration', function () {
-      assert.strictEqual(containsDoctype('<root><!-- just an unterminated comment'), false);
+    it('should detect a DOCTYPE behind a bogus prefix with a trailing comment closer', function () {
+      assert.strictEqual(
+        containsDoctype(
+          '<!<!--><!DOCTYPE evil [ <!ENTITY x SYSTEM "file:///etc/passwd"> ]><root>ok</root><!-- -->'
+        ),
+        true
+      );
     });
 
-    it('should scan large adversarial input without quadratic blow-up', function () {
-      // Many unterminated comment openers must not force per-opener rescans; the
-      // exhausted-closer flag keeps the pass linear.
+    it('should scan large adversarial input in linear time', function () {
+      // A fixed-alternation keyword search has no backtracking, so many
+      // comment-like openers with no DTD keyword stay linear and return false.
       const hostile = '<!--'.repeat(200000);
       const start = Date.now();
       assert.strictEqual(containsDoctype(hostile), false);

--- a/test/lib/utils.spec.ts
+++ b/test/lib/utils.spec.ts
@@ -50,6 +50,16 @@ describe('utils.ts', function () {
       assert(doc);
       assert.strictEqual(doc.documentElement?.nodeName, 'root');
     });
+
+    // A malformed DTD must yield the fixed error, not raw @xmldom/xmldom text
+    // from the parser (which the doctype-only check let through before parsing).
+    it('should reject a malformed/unterminated DTD with the fixed error', function () {
+      assert.throws(
+        () => parseFromString('<!DOCTYPE foo SYSTEM "file:///nope" <Root/>'),
+        doctypeNotAllowedError
+      );
+      assert.throws(() => parseFromString('<!DOCTYPE foo'), doctypeNotAllowedError);
+    });
   });
 
   // xml2js/sax does not expose a parsed doctype node, so its callers screen the
@@ -72,6 +82,20 @@ describe('utils.ts', function () {
 
     it('should detect an ELEMENT declaration', function () {
       assert.strictEqual(containsDoctype('<!ELEMENT r (#PCDATA)>'), true);
+    });
+
+    // sax enters its doctype state on the bare keyword, without the whitespace
+    // the XML grammar requires, so the guard must too.
+    it('should detect a whitespace-free DOCTYPE declaration', function () {
+      assert.strictEqual(containsDoctype('<!DOCTYPERoot SYSTEM "file:///x"><Root/>'), true);
+    });
+
+    it('should detect a whitespace-free ENTITY declaration', function () {
+      assert.strictEqual(containsDoctype('<!ENTITYx SYSTEM "file:///x">'), true);
+    });
+
+    it('should detect a whitespace-free ELEMENT declaration', function () {
+      assert.strictEqual(containsDoctype('<!ELEMENTr (#PCDATA)>'), true);
     });
 
     it('should be case-insensitive', function () {

--- a/test/lib/utils.spec.ts
+++ b/test/lib/utils.spec.ts
@@ -73,6 +73,21 @@ describe('utils.ts', function () {
     it('should return false for XML without a DOCTYPE', function () {
       assert.strictEqual(containsDoctype('<?xml version="1.0"?><root><a>hi</a></root>'), false);
     });
+
+    it('should ignore <!DOCTYPE inside a comment', function () {
+      assert.strictEqual(containsDoctype('<root><!-- <!DOCTYPE example> --><a>hi</a></root>'), false);
+    });
+
+    it('should ignore <!DOCTYPE inside a CDATA section', function () {
+      assert.strictEqual(
+        containsDoctype('<root><AttributeValue><![CDATA[<!DOCTYPE example>]]></AttributeValue></root>'),
+        false
+      );
+    });
+
+    it('should still detect a real DOCTYPE that follows a comment', function () {
+      assert.strictEqual(containsDoctype('<!-- a comment --><!DOCTYPE r><r/>'), true);
+    });
   });
 
   describe('thumbprint', function () {


### PR DESCRIPTION
Addresses part of https://github.com/ory/polis/issues/4071

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Improvements**
  * XML documents containing DOCTYPE, ENTITY, or ELEMENT declarations are now rejected across supported parsing flows.
  * Potentially unsafe external entity and XXE payloads are blocked before XML parsing.
  * Declarations embedded in comments, CDATA sections, or processing instructions are ignored.
  * Valid XML without these declarations continues to be accepted.

* **New Features**
  * Added a public utility for checking XML content for prohibited declarations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->