### PR TITLE
feat: add algorithm allowlist option to validateSignature

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ const issuer = saml.parseIssuer(rawResponse);
 - `publicKey` is the trusted public key.
 - `audience` (optional). If it is included audience validation will take place.
 - `bypassExpiration` (optional). This flag indicates expiration validation bypass (useful for testing, not recommended in production environments);
+- `allowedSignatureAlgorithms` / `allowedHashAlgorithms` (optional). Algorithm allowlists forwarded to `validateSignature`, see below.
 
 You can use either `thumbprint` or `publicKey` but you should use at least one.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,32 @@ saml.validate(rawAssertion, options, function (err, profile) {
 });
 ```
 
+### saml.validateSignature(xml, publicKey, thumbprint, options?)
+
+Verifies the XML signature on `xml` and returns the signed XML, or throws / returns `null` when the signature is invalid. Pass either `publicKey` (one certificate, or several separated by commas for key rotation) or `thumbprint`, not both.
+
+`options` (optional) restricts which algorithms are accepted:
+
+- `allowedSignatureAlgorithms` — accepted `SignatureMethod` URIs.
+- `allowedHashAlgorithms` — accepted `DigestMethod` URIs.
+
+When an allowlist is omitted, the default set from `xml-crypto` applies (RSA-SHA1, RSA-SHA256, RSA-SHA512 and SHA-1, SHA-256, SHA-512 digests). When one is given, a document using any other algorithm is rejected; an empty list rejects everything.
+
+```javascript
+var saml = require('@boxyhq/saml20').default;
+
+var signedXml = saml.validateSignature(xml, publicKey, null, {
+  allowedSignatureAlgorithms: [
+    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
+    'http://www.w3.org/2001/04/xmldsig-more#rsa-sha512',
+  ],
+  allowedHashAlgorithms: [
+    'http://www.w3.org/2001/04/xmlenc#sha256',
+    'http://www.w3.org/2001/04/xmlenc#sha512',
+  ],
+});
+```
+
 ## Tests
 
 ### Configure test/lib.index.js

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import { validateSignature, certToPEM } from './validateSignature';
+import type { ValidateSignatureOptions } from './validateSignature';
 
 import { request, parseSAMLRequest, decodeBase64 } from './request';
 import { stripCertHeaderAndFooter, PubKeyInfo } from './cert';
@@ -44,4 +45,10 @@ export default {
   createLogoutResponse,
 };
 
-export type { ParsedLogoutResponse, LogoutRequestParams, ParsedLogoutRequest, LogoutResponseParams };
+export type {
+  ParsedLogoutResponse,
+  LogoutRequestParams,
+  ParsedLogoutRequest,
+  LogoutResponseParams,
+  ValidateSignatureOptions,
+};

--- a/lib/response.ts
+++ b/lib/response.ts
@@ -4,6 +4,7 @@ import xmlbuilder from 'xmlbuilder';
 import crypto from 'crypto';
 import { getVersion } from './getVersion';
 import { validateSignature, sanitizeXML } from './validateSignature';
+import type { ValidateSignatureOptions } from './validateSignature';
 import { decryptXml } from './decrypt';
 import { select } from 'xpath';
 import saml20 from './saml20';
@@ -124,6 +125,13 @@ const validateInternal = async (rawAssertion, options, cb) => {
     return;
   }
 
+  // Optional algorithm allowlists, forwarded to validateSignature. Leaving
+  // them out keeps the permissive defaults.
+  const signatureOptions: ValidateSignatureOptions = {
+    allowedSignatureAlgorithms: options.allowedSignatureAlgorithms,
+    allowedHashAlgorithms: options.allowedHashAlgorithms,
+  };
+
   // eslint-disable-next-line no-useless-assignment
   let decAssertion = false;
   try {
@@ -151,7 +159,7 @@ const validateInternal = async (rawAssertion, options, cb) => {
   let signedXml: string | null;
 
   try {
-    signedXml = validateSignature(rawAssertion, options.publicKey, options.thumbprint);
+    signedXml = validateSignature(rawAssertion, options.publicKey, options.thumbprint, signatureOptions);
   } catch (e) {
     const error = new WrapError('Invalid assertion.');
     error.inner = e;
@@ -162,7 +170,12 @@ const validateInternal = async (rawAssertion, options, cb) => {
   if (decAssertion && !signedXml) {
     // try the fallback verification where signature has been generated on the encrypted SAML by some IdPs (like OpenAthens)
     try {
-      signedXml = validateSignature(originalAssertion, options.publicKey, options.thumbprint);
+      signedXml = validateSignature(
+        originalAssertion,
+        options.publicKey,
+        options.thumbprint,
+        signatureOptions
+      );
     } catch (e) {
       const error = new WrapError('Invalid assertion.');
       error.inner = e;

--- a/lib/validateSignature.ts
+++ b/lib/validateSignature.ts
@@ -2,6 +2,31 @@ import { SignedXml } from 'xml-crypto';
 import { select } from 'xpath';
 import { parseFromString, thumbprint } from './utils';
 
+/**
+ * Optional constraints applied while verifying an XML signature.
+ *
+ * When an allowlist is provided, only the listed algorithm URIs are accepted
+ * for that role; a document signed (or digested) with anything else is
+ * rejected. When an allowlist is omitted, the permissive defaults from
+ * xml-crypto apply (which currently include SHA-1), so existing callers are
+ * unaffected.
+ *
+ * An empty allowlist, or one that names only algorithms xml-crypto does not
+ * implement, accepts nothing.
+ */
+export interface ValidateSignatureOptions {
+  /**
+   * Accepted `SignatureMethod` algorithm URIs, e.g.
+   * `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256`.
+   */
+  allowedSignatureAlgorithms?: string[];
+  /**
+   * Accepted `DigestMethod` algorithm URIs, e.g.
+   * `http://www.w3.org/2001/04/xmlenc#sha256`.
+   */
+  allowedHashAlgorithms?: string[];
+}
+
 const isMultiCert = (cert) => {
   return cert.indexOf(',') !== -1;
 };
@@ -17,17 +42,77 @@ const certToPEM = (cert) => {
   }
 };
 
+// Keep only the entries of an xml-crypto algorithm registry that are named in
+// the allowlist. Any lookup for an algorithm outside the result makes
+// xml-crypto throw "<kind> algorithm '<uri>' is not supported", so nothing
+// outside the allowlist can verify.
+const restrictRegistry = <T extends Record<string, unknown>>(registry: T, allowed: string[]): T => {
+  const restricted = {} as T;
+  for (const uri of allowed) {
+    if (Object.prototype.hasOwnProperty.call(registry, uri)) {
+      restricted[uri as keyof T] = registry[uri as keyof T];
+    }
+  }
+  return restricted;
+};
+
+// Narrow the algorithm registries on a SignedXml instance according to the
+// options. The instance is shared by every verification attempt (including
+// the multi-certificate loop), so narrowing it once after construction is
+// sufficient.
+const applyAlgorithmAllowlists = (signed: SignedXml, options?: ValidateSignatureOptions) => {
+  if (!options) {
+    return;
+  }
+  if (options.allowedSignatureAlgorithms !== undefined) {
+    signed.SignatureAlgorithms = restrictRegistry(
+      signed.SignatureAlgorithms,
+      options.allowedSignatureAlgorithms
+    );
+  }
+  if (options.allowedHashAlgorithms !== undefined) {
+    signed.HashAlgorithms = restrictRegistry(signed.HashAlgorithms, options.allowedHashAlgorithms);
+  }
+};
+
+// Fail early, with a specific error, when the document declares an algorithm
+// outside the allowlists. The narrowed registries above are the actual
+// enforcement; this only turns the generic "not supported" (which the
+// multi-certificate loop would otherwise swallow) into a clear message.
+const assertAllowedAlgorithms = (signed: SignedXml, signature, options?: ValidateSignatureOptions) => {
+  if (!options) {
+    return;
+  }
+  if (options.allowedSignatureAlgorithms !== undefined) {
+    const signatureAlgorithm = signed.signatureAlgorithm;
+    if (!signatureAlgorithm || !signed.SignatureAlgorithms[signatureAlgorithm]) {
+      throw new Error(`invalid signature: signature algorithm '${signatureAlgorithm}' is not allowed`);
+    }
+  }
+  if (options.allowedHashAlgorithms !== undefined) {
+    const digestMethods = select(".//*[local-name(.)='DigestMethod']/@Algorithm", signature) as Attr[];
+    if (digestMethods.length === 0) {
+      throw new Error('invalid signature: no DigestMethod found in signature');
+    }
+    for (const digestMethod of digestMethods) {
+      if (!signed.HashAlgorithms[digestMethod.value]) {
+        throw new Error(`invalid signature: digest algorithm '${digestMethod.value}' is not allowed`);
+      }
+    }
+  }
+};
+
 // Breaking Change: hasValidSignature now returns:
 // if signature is valid: the raw signed xml string
 // if signature is invalid: throws error or returns null
 // clients are to use the resultant raw xml string to parse their SAML Assertion
 // should be internal
-const hasValidSignature = (xml, cert, certThumbprint): string | null => {
+const hasValidSignature = (xml, cert, certThumbprint, options?: ValidateSignatureOptions): string | null => {
   xml = sanitizeXML(xml);
-  return _hasValidSignature(xml, cert, certThumbprint);
+  return _hasValidSignature(xml, cert, certThumbprint, options);
 };
 
-const _hasValidSignature = (xml, cert, certThumbprint): string | null => {
+const _hasValidSignature = (xml, cert, certThumbprint, options?: ValidateSignatureOptions): string | null => {
   const doc = parseFromString(xml);
   let signature =
     select(
@@ -55,7 +140,11 @@ const _hasValidSignature = (xml, cert, certThumbprint): string | null => {
     idAttribute: 'AssertionID',
   });
 
+  applyAlgorithmAllowlists(signed, options);
+
   signed.loadSignature(signature);
+
+  assertAllowedAlgorithms(signed, signature, options);
 
   let valid;
   // Check if cert contains multiple
@@ -121,12 +210,12 @@ const _hasValidSignature = (xml, cert, certThumbprint): string | null => {
 // if signature is invalid: throws error or returns null
 // clients are to use the resultant raw xml string to parse their SAML Assertion
 
-const validateSignature = (xml, cert, certThumbprint) => {
+const validateSignature = (xml, cert, certThumbprint, options?: ValidateSignatureOptions) => {
   if (cert && certThumbprint) {
     throw new Error('You should provide either cert or certThumbprint, not both');
   }
 
-  return hasValidSignature(xml, cert, certThumbprint);
+  return hasValidSignature(xml, cert, certThumbprint, options);
 };
 
 const sanitizeXML = (xml) => {

--- a/lib/validateSignature.ts
+++ b/lib/validateSignature.ts
@@ -90,7 +90,14 @@ const assertAllowedAlgorithms = (signed: SignedXml, signature, options?: Validat
     }
   }
   if (options.allowedHashAlgorithms !== undefined) {
-    const digestMethods = select(".//*[local-name(.)='DigestMethod']/@Algorithm", signature) as Attr[];
+    // Only SignedInfo's direct Reference children are validated by xml-crypto,
+    // so only those DigestMethods are checked here. Scanning the whole
+    // Signature subtree would let an unsigned ds:Object/Manifest carrying a
+    // disallowed DigestMethod reject an otherwise valid document.
+    const digestMethods = select(
+      "./*[local-name(.)='SignedInfo']/*[local-name(.)='Reference']/*[local-name(.)='DigestMethod']/@Algorithm",
+      signature
+    ) as Attr[];
     if (digestMethods.length === 0) {
       throw new Error('invalid signature: no DigestMethod found in signature');
     }

--- a/test/lib/saml20.response.spec.ts
+++ b/test/lib/saml20.response.spec.ts
@@ -44,6 +44,54 @@ describe('lib.saml20.response', function () {
     );
   });
 
+  it('Should honour algorithm allowlists passed to validate()', async function () {
+    // saml20.validResponse.xml is signed with RSA-SHA1 / SHA-1
+    const sha1Options = {
+      allowedSignatureAlgorithms: ['http://www.w3.org/2000/09/xmldsig#rsa-sha1'],
+      allowedHashAlgorithms: ['http://www.w3.org/2000/09/xmldsig#sha1'],
+    };
+    const sha2Options = {
+      allowedSignatureAlgorithms: ['http://www.w3.org/2001/04/xmldsig-more#rsa-sha256'],
+      allowedHashAlgorithms: ['http://www.w3.org/2001/04/xmlenc#sha256'],
+    };
+
+    const response = await validate(validResponse, {
+      publicKey: certificate,
+      bypassExpiration: true,
+      inResponseTo: inResponseTo,
+      ...sha1Options,
+    });
+    assert.strictEqual(response.issuer, issuerName);
+
+    await assert.rejects(
+      validate(validResponse, {
+        publicKey: certificate,
+        bypassExpiration: true,
+        inResponseTo: inResponseTo,
+        ...sha2Options,
+      }),
+      (err: any) => {
+        assert.strictEqual(err.message, 'Invalid assertion.');
+        assert.match(err.inner.message, /signature algorithm '.*rsa-sha1' is not allowed/);
+        return true;
+      }
+    );
+
+    // thumbprint path
+    await assert.rejects(
+      validate(validResponse, {
+        thumbprint: thumbprint,
+        bypassExpiration: true,
+        inResponseTo: inResponseTo,
+        allowedHashAlgorithms: sha2Options.allowedHashAlgorithms,
+      }),
+      (err: any) => {
+        assert.match(err.inner.message, /digest algorithm '.*sha1' is not allowed/);
+        return true;
+      }
+    );
+  });
+
   it('Should validate saml 2.0 token and check audience', async function () {
     const response = await validate(validResponse, {
       publicKey: certificate,

--- a/test/lib/validateSignature.spec.ts
+++ b/test/lib/validateSignature.spec.ts
@@ -491,6 +491,25 @@ describe('validateSignature.ts - algorithm allowlists', function () {
     assert.throws(() => signed.checkSignature(doc), /signature algorithm .* is not supported/);
   });
 
+  it('digest allowlist ignores DigestMethods outside SignedInfo (unsigned ds:Object/Manifest)', function () {
+    // A ds:Object is not covered by the enveloped signature, so anyone can
+    // append one. Its Manifest DigestMethod must not be able to reject a valid
+    // SHA-256 document under a SHA-2-only allowlist.
+    const doc = generateXML();
+    const manifest =
+      '<Object xmlns="http://www.w3.org/2000/09/xmldsig#"><Manifest><Reference URI="#nothing">' +
+      `<DigestMethod Algorithm="${SHA1}"/><DigestValue>AAAAAAAAAAAAAAAAAAAAAAAAAAA=</DigestValue>` +
+      '</Reference></Manifest></Object>';
+    const tampered = doc.replace('</Signature>', manifest + '</Signature>');
+    assert.notStrictEqual(tampered, doc);
+    assert(validateSignature(tampered, publicKey, null, sha2Only));
+    // and the real SignedInfo digest is still enforced on the same document
+    assert.throws(
+      () => validateSignature(tampered, publicKey, null, { allowedHashAlgorithms: [SHA1] }),
+      /digest algorithm '.*sha256' is not allowed/
+    );
+  });
+
   it('multi-certificate rotation: SHA-256 document accepted under a SHA-2-only allowlist', function () {
     const rotated = `${singlePublicKeyNotUsedToSign},${publicKey}`;
     assert(validateSignature(generateXML(), rotated, null, sha2Only));

--- a/test/lib/validateSignature.spec.ts
+++ b/test/lib/validateSignature.spec.ts
@@ -4,6 +4,9 @@ import xmlbuilder from 'xmlbuilder';
 import crypto from 'crypto';
 import fs from 'fs';
 import { sign } from '../../lib/sign';
+import { SignedXml } from 'xml-crypto';
+import { PubKeyInfo } from '../../lib/cert';
+import { thumbprint } from '../../lib/utils';
 import assert from 'assert';
 
 const ssoUrl =
@@ -179,7 +182,42 @@ NDvfSxFNmjcEuabxM9VGdsX6xOiClZBJwJBixj74EYPeeVOPbOEQfQZchX8xB3u5
 2knHSNiamr0NJ4GA44hIoCADW2G6W2+A4gFNnA6UYFlaijMWqb/XSNlbkYZD6OkG
 9Xa5bTycscrxF6+S3n5z2yGft52wBe4=`;
 
-function generateXML() {
+const RSA_SHA1 = 'http://www.w3.org/2000/09/xmldsig#rsa-sha1';
+const RSA_SHA256 = 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256';
+const SHA1 = 'http://www.w3.org/2000/09/xmldsig#sha1';
+const SHA256 = 'http://www.w3.org/2001/04/xmlenc#sha256';
+
+// Build the same AuthnRequest as generateXML() but sign it with RSA-SHA1 and a
+// SHA-1 digest, so the SHA-1 fixture carries a genuine signature rather than a
+// SHA-256 document with its algorithm URIs edited.
+function generateSha1SignedXML() {
+  const unsigned = generateXML({ sign: false });
+  const sig = new SignedXml({
+    privateKey: signingKey,
+    signatureAlgorithm: RSA_SHA1,
+    getKeyInfoContent: PubKeyInfo(publicKey),
+    canonicalizationAlgorithm: 'http://www.w3.org/2001/10/xml-exc-c14n#',
+  });
+  sig.addReference({
+    xpath: authnXPath,
+    transforms: [
+      'http://www.w3.org/2000/09/xmldsig#enveloped-signature',
+      'http://www.w3.org/2001/10/xml-exc-c14n#',
+    ],
+    digestAlgorithm: SHA1,
+  });
+  sig.computeSignature(unsigned, {
+    location: {
+      reference:
+        authnXPath +
+        '/*[local-name(.)="Issuer" and namespace-uri(.)="urn:oasis:names:tc:SAML:2.0:assertion"]',
+      action: 'after',
+    },
+  });
+  return sig.getSignedXml();
+}
+
+function generateXML({ sign: shouldSign = true } = {}) {
   const id = idPrefix + crypto.randomBytes(10).toString('hex');
   const date = new Date().toISOString();
 
@@ -218,7 +256,7 @@ function generateXML() {
   }
 
   let xml = xmlbuilder.create(samlReq).end({});
-  if (signingKey) {
+  if (shouldSign && signingKey) {
     xml = sign(xml, signingKey, publicKey, authnXPath);
   }
   return xml;
@@ -358,5 +396,131 @@ sT/txBnVJGziyO8DPYdu2fPMER8ajJfl</X509Certificate>
     } catch (error) {
       assert(error);
     }
+  });
+});
+
+describe('validateSignature.ts - algorithm allowlists', function () {
+  const sha2Only = { allowedSignatureAlgorithms: [RSA_SHA256], allowedHashAlgorithms: [SHA256] };
+
+  it('fixtures use the algorithms the tests assume', function () {
+    const sha256Doc = generateXML();
+    assert(sha256Doc.includes(`SignatureMethod Algorithm="${RSA_SHA256}"`));
+    assert(sha256Doc.includes(`DigestMethod Algorithm="${SHA256}"`));
+    const sha1Doc = generateSha1SignedXML();
+    assert(sha1Doc.includes(`SignatureMethod Algorithm="${RSA_SHA1}"`));
+    assert(sha1Doc.includes(`DigestMethod Algorithm="${SHA1}"`));
+  });
+
+  it('accepts a SHA-256 signed document when the allowlist includes SHA-256', function () {
+    assert(validateSignature(generateXML(), publicKey, null, sha2Only));
+    assert(hasValidSignature(generateXML(), publicKey, null, sha2Only));
+  });
+
+  it('accepts a SHA-256 signed document with a wider allowlist', function () {
+    assert(
+      validateSignature(generateXML(), publicKey, null, {
+        allowedSignatureAlgorithms: [RSA_SHA1, RSA_SHA256],
+        allowedHashAlgorithms: [SHA1, SHA256],
+      })
+    );
+  });
+
+  it('rejects a SHA-256 signed document when the signature algorithm allowlist excludes it', function () {
+    assert.throws(
+      () => validateSignature(generateXML(), publicKey, null, { allowedSignatureAlgorithms: [RSA_SHA1] }),
+      /signature algorithm '.*rsa-sha256' is not allowed/
+    );
+  });
+
+  it('rejects a SHA-256 signed document when the digest algorithm allowlist excludes it', function () {
+    assert.throws(
+      () => validateSignature(generateXML(), publicKey, null, { allowedHashAlgorithms: [SHA1] }),
+      /digest algorithm '.*sha256' is not allowed/
+    );
+  });
+
+  it('accepts a SHA-1 signed document when no options are passed (compatibility)', function () {
+    assert(validateSignature(generateSha1SignedXML(), publicKey, null));
+    assert(validateSignature(generateSha1SignedXML(), publicKey, null, {}));
+    assert(
+      validateSignature(generateSha1SignedXML(), publicKey, null, { allowedSignatureAlgorithms: [RSA_SHA1] })
+    );
+  });
+
+  it('rejects a SHA-1 signed document under a SHA-2-only allowlist', function () {
+    assert.throws(
+      () => validateSignature(generateSha1SignedXML(), publicKey, null, sha2Only),
+      /signature algorithm '.*rsa-sha1' is not allowed/
+    );
+    // digest constrained on its own: signature method passes, digest does not
+    assert.throws(
+      () => validateSignature(generateSha1SignedXML(), publicKey, null, { allowedHashAlgorithms: [SHA256] }),
+      /digest algorithm '.*sha1' is not allowed/
+    );
+  });
+
+  it('fails closed on an empty allowlist', function () {
+    assert.throws(
+      () => validateSignature(generateXML(), publicKey, null, { allowedSignatureAlgorithms: [] }),
+      /signature algorithm .* is not allowed/
+    );
+    assert.throws(
+      () => validateSignature(generateXML(), publicKey, null, { allowedHashAlgorithms: [] }),
+      /digest algorithm .* is not allowed/
+    );
+  });
+
+  it('fails closed on an allowlist naming only unknown algorithms', function () {
+    assert.throws(
+      () =>
+        validateSignature(generateXML(), publicKey, null, {
+          allowedSignatureAlgorithms: ['http://example.com/not-an-algorithm'],
+        }),
+      /signature algorithm .* is not allowed/
+    );
+  });
+
+  it('narrowed registries enforce the allowlist independently of the early check', function () {
+    // Sanity check on the mechanism itself: a SignedXml whose registry has been
+    // reduced the way validateSignature reduces it refuses to verify, so an
+    // excluded algorithm can never verify even without the explicit pre-check.
+    const doc = generateXML();
+    const signed = new SignedXml({ publicCert: publicKey });
+    signed.loadSignature(doc.match(/<Signature[\s\S]*<\/Signature>/)![0]);
+    signed.SignatureAlgorithms = {} as typeof signed.SignatureAlgorithms;
+    assert.throws(() => signed.checkSignature(doc), /signature algorithm .* is not supported/);
+  });
+
+  it('multi-certificate rotation: SHA-256 document accepted under a SHA-2-only allowlist', function () {
+    const rotated = `${singlePublicKeyNotUsedToSign},${publicKey}`;
+    assert(validateSignature(generateXML(), rotated, null, sha2Only));
+    assert(validateSignature(validResponseSigned_noX509, multiPublicKey, null, sha2Only));
+    assert(validateSignature(validResponseSigned_noX509, multiPublicKeyOrderChanged, null, sha2Only));
+  });
+
+  it('multi-certificate rotation: SHA-1 document rejected under a SHA-2-only allowlist', function () {
+    const rotated = `${singlePublicKeyNotUsedToSign},${publicKey}`;
+    // no options: still accepted through the rotation path
+    assert(validateSignature(generateSha1SignedXML(), rotated, null));
+    assert.throws(
+      () => validateSignature(generateSha1SignedXML(), rotated, null, sha2Only),
+      /signature algorithm '.*rsa-sha1' is not allowed/
+    );
+  });
+
+  it('multi-certificate rotation: wrong certificates still fail with the existing error', function () {
+    assert.throws(
+      () => validateSignature(validResponseSigned_noX509, wrongMultiPublicKey, null, sha2Only),
+      /Failed to verify signature against all the certificates provided/
+    );
+  });
+
+  it('thumbprint branch honours the allowlist', function () {
+    const sha1Doc = generateSha1SignedXML();
+    const embedded = sha1Doc.match(/<X509Certificate>([^<]+)<\/X509Certificate>/)![1];
+    const fp = thumbprint(embedded);
+    assert(validateSignature(sha1Doc, null, fp));
+    assert.throws(() => validateSignature(sha1Doc, null, fp, sha2Only), /rsa-sha1' is not allowed/);
+    assert(validateSignature(generateXML(), null, fp, sha2Only));
   });
 });


### PR DESCRIPTION
Add an optional fourth argument to validateSignature / hasValidSignature carrying allowedSignatureAlgorithms and allowedHashAlgorithms. When a list is given, the matching registry on the xml-crypto SignedXml instance is reduced to the listed entries before checkSignature runs, so any other algorithm fails with a clear error. Omitting the options keeps today's permissive defaults.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - XML signature validation supports optional allowlists for approved signature and digest algorithms.
  - Signatures using algorithms outside configured allowlists are rejected.
  - Validation accepts a single certificate, multiple comma-separated certificates for key rotation, or a certificate thumbprint.
  - Algorithm restrictions are supported for standard and encrypted SAML responses while preserving existing defaults when omitted.

- **Documentation**
  - Added usage guidance and examples for signature validation, certificate options, algorithm restrictions, and default allowlist behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->